### PR TITLE
Fixed Error in "Alert for early 2022" section.

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,12 +22,12 @@ VRChat is switching to SPS-I.  Please perform the following to test your shaders
 
 Add this to your appdata:
 ```glsl
-	UNITY_VERTEX_INPUT_INSTANCE_ID;
+	UNITY_VERTEX_INPUT_INSTANCE_ID
 ```
 
 Add this to your `v2f` struct:
 ```glsl
-	UNITY_VERTEX_OUTPUT_STEREO;
+	UNITY_VERTEX_OUTPUT_STEREO
 ```
 
 Add this to your `vertex` shader:


### PR DESCRIPTION
UNITY_VERTEX_INPUT_INSTANCE_ID and UNITY_VERTEX_OUTPUT_STEREO should not be followed by semicolons. Doing so produces an error. 

Removing the semicolons produces the expected result.